### PR TITLE
fix: Add explicit serviceAccountName to Logstash GlobalService for proper credentials

### DIFF
--- a/bootstrap/o11y/elastic.yaml
+++ b/bootstrap/o11y/elastic.yaml
@@ -19,6 +19,7 @@ metadata:
 spec:
   template:
     namespace: elastic
+    serviceAccountName: stacks
     repositoryRef:
       name: infra
       namespace: infra


### PR DESCRIPTION
### Summary

The Logstash GlobalService in the infra namespace was stuck in pending provisioning because it was using default credentials instead of explicit and valid ones. This fix explicitly sets the `serviceAccountName` to `stacks` in the GlobalService specification, which provides the necessary credentials via the existing ServiceAccount annotated with the appropriate AWS IAM role.

### Changes Made

- Added `serviceAccountName: stacks` under `spec.template` in `bootstrap/o11y/elastic.yaml` for the Logstash GlobalService.

### Rationale

This change ensures the Plural GitOps agent managing the GlobalService has proper credentials for Git and Kubernetes access, including cross-namespace permissions, thus resolving the stuck provisioning issue and enabling successful deployment.

If permission issues persist, further verification of the IAM role's RBAC permissions is recommended.